### PR TITLE
Get filename from url if file from urllib.urlopen 

### DIFF
--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -272,6 +272,11 @@ def get(f, default=NoDefault, filename=None, type=None):
             if default is not NoDefault:
                 return default
             raise FullTextException('File not found')
+    if not filename:
+        try:
+            filename = os.path.basename(req.url)
+        except AttributeError:
+            pass
     if type is None:
         type = get_type(filename)
     handler = FUNC_MAP.get(type, read_content)


### PR DESCRIPTION
If the file object comes from urllib.urlopen, it won't have a .name attribute, but sometimes you can get the filename from the URL.
