### PR TITLE
Open files for backend using 'rb'.

### DIFF
--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -78,7 +78,7 @@ def _get_path(backend, path, **kwargs):
     elif callable(getattr(backend, '_get_file', None)):
         # Fallback to _get_file(). No warning here since the performance hit
         # is minimal.
-        with open(path, 'r') as f:
+        with open(path, 'rb') as f:
             return backend._get_file(f, **kwargs)
 
 


### PR DESCRIPTION
Fixes:

```Traceback (most recent call last):
  File "/usr/lib/python3.6/concurrent/futures/process.py", line 175, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/giampaolo/svn/smartfile/duster/duster/crawler.py", line 26, in process_file
    for fp in fingerprints:
  File "/home/giampaolo/svn/smartfile/duster/duster/__init__.py", line 263, in dust
    for fn, type, size, ct, mt, raw, text in unwrap(path):
  File "/home/giampaolo/svn/smartfile/duster/duster/containers.py", line 230, in unwrap
    for item in unwrap_text(path, type):
  File "/home/giampaolo/svn/smartfile/duster/duster/containers.py", line 152, in unwrap_text
    text = fulltext.get(path, **kwargs)
  File "/home/giampaolo/svn/smartfile/fulltext/fulltext/__init__.py", line 146, in get
    backend, path_or_file, mime=mime, name=name, **kwargs)
  File "/home/giampaolo/svn/smartfile/fulltext/fulltext/__init__.py", line 82, in _get_path
    return backend._get_file(f, **kwargs)
  File "/home/giampaolo/svn/smartfile/fulltext/fulltext/backends/__text.py", line 20, in _get_file
    text = f.read(BUFFER_MAX)
  File "/home/giampaolo/svn/smartfile/duster/venv3/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 10: invalid continuation byte```