### PR TITLE
remove _ suffix from backend functions

### DIFF
--- a/fulltext/backends/__gz.py
+++ b/fulltext/backends/__gz.py
@@ -4,7 +4,7 @@ from os.path import splitext, basename
 from fulltext import get, backend_from_fname, backend_from_fobj, is_file_path
 
 
-def _orig_fname(s):
+def orig_fname(s):
     s = basename(s)
     if s.lower().endswith('.gz'):
         s = s[:-3]
@@ -24,7 +24,7 @@ def handle_fobj(path_or_file, **kwargs):
         path = f.name
 
     with f:
-        orig_name = _orig_fname(path)
+        orig_name = orig_fname(path)
         if _has_ext(orig_name) and splitext(orig_name)[1].lower() != '.gz':
             backend = backend_from_fname(orig_name)
         else:

--- a/fulltext/backends/__html.py
+++ b/fulltext/backends/__html.py
@@ -8,7 +8,7 @@ from six import StringIO
 from six import PY3
 
 
-def _is_visible(elem, encoding, errors):
+def is_visible(elem, encoding, errors):
     if elem.parent.name in ['style', 'script', '[document]', 'head']:
         return False
 
@@ -27,7 +27,7 @@ def handle_fobj(f, **kwargs):
     text, bs = StringIO(), BeautifulSoup(data, 'lxml')
 
     for elem in bs.findAll(text=True):
-        if _is_visible(elem, encoding, errors):
+        if is_visible(elem, encoding, errors):
             text.write(elem)
             text.write(u' ')
 

--- a/fulltext/backends/__hwp.py
+++ b/fulltext/backends/__hwp.py
@@ -8,7 +8,7 @@ def check():
     assert_cmd_exists('hwp5proc')
 
 
-def _cmd(path, **kwargs):
+def cmd(path, **kwargs):
     cmd = ['hwp5proc', 'xml']
     cmd.extend([path])
     return cmd
@@ -20,5 +20,5 @@ def to_text_with_backend(html):
 
 def handle_path(path, **kwargs):
     encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return to_text_with_backend(run(*_cmd(path, **kwargs)).decode(
+    return to_text_with_backend(run(*cmd(path, **kwargs)).decode(
         encoding, errors))

--- a/fulltext/backends/__json.py
+++ b/fulltext/backends/__json.py
@@ -10,15 +10,15 @@ SCALAR_TYPES = string_types + integer_types
 ENCODING = sys.getfilesystemencoding()
 
 
-def _to_text(text, obj):
+def to_text(text, obj):
     if isinstance(obj, dict):
         for key in sorted(obj.keys()):
-            _to_text(text, key)
-            _to_text(text, obj[key])
+            to_text(text, key)
+            to_text(text, obj[key])
 
     elif isinstance(obj, list):
         for item in obj:
-            _to_text(text, item)
+            to_text(text, item)
 
     elif isinstance(obj, SCALAR_TYPES):
         text.write(u'%s ' % obj)
@@ -34,6 +34,6 @@ def handle_fobj(f, **kwargs):
     # TODO: catch exception and attempt to use regex to strip formatting.
     obj = json.loads(data.decode(encoding, errors))
 
-    _to_text(text, obj)
+    to_text(text, obj)
 
     return text.getvalue()

--- a/fulltext/backends/__odt.py
+++ b/fulltext/backends/__odt.py
@@ -6,7 +6,7 @@ from lxml import etree
 from six import StringIO
 
 
-def _qn(ns):
+def qn(ns):
     nsmap = {
         'text': 'urn:oasis:names:tc:opendocument:xmlns:text:1.0',
     }
@@ -14,18 +14,18 @@ def _qn(ns):
     return '{{{}}}{}'.format(nsmap[one], two)
 
 
-def _to_string(text, elem):
+def to_string(text, elem):
     if elem.text is not None:
         text.write(elem.text)
     for c in elem:
-        if c.tag == _qn('text:tab'):
+        if c.tag == qn('text:tab'):
             text.write(' ')
-        elif c.tag == _qn('text:s'):
+        elif c.tag == qn('text:s'):
             text.write(' ')
             if c.tail is not None:
                 text.write(c.tail)
         else:
-            _to_string(text, c)
+            to_string(text, c)
     text.write(u'\n')
 
 
@@ -37,8 +37,8 @@ def handle_fobj(f, **kwargs):
             xml = etree.parse(c)
 
             for c in xml.iter():
-                if c.tag in (_qn('text:p'), _qn('text:h')):
-                    _to_string(text, c)
+                if c.tag in (qn('text:p'), qn('text:h')):
+                    to_string(text, c)
 
     return text.getvalue()
 

--- a/fulltext/backends/__pdf.py
+++ b/fulltext/backends/__pdf.py
@@ -6,7 +6,7 @@ def check():
     assert_cmd_exists('pdftotext')
 
 
-def _cmd(path, **kwargs):
+def cmd(path, **kwargs):
     cmd = ['pdftotext']
 
     if kwargs.get('layout', None):
@@ -19,9 +19,9 @@ def _cmd(path, **kwargs):
 
 def handle_fobj(f, **kwargs):
     encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return run(*_cmd('-', **kwargs), stdin=f).decode(encoding, errors)
+    return run(*cmd('-', **kwargs), stdin=f).decode(encoding, errors)
 
 
 def handle_path(path, **kwargs):
     encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return run(*_cmd(path, **kwargs)).decode(encoding, errors)
+    return run(*cmd(path, **kwargs)).decode(encoding, errors)

--- a/fulltext/backends/__rtf.py
+++ b/fulltext/backends/__rtf.py
@@ -7,17 +7,17 @@ def check():
     assert_cmd_exists('unrtf')
 
 
-def _strip(text, encoding, errors):
+def strip(text, encoding, errors):
     return text.partition(b'-----------------')[2].decode(encoding, errors)
 
 
 def handle_fobj(f, **kwargs):
     encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return _strip(run('unrtf', '--text', '--nopict', stdin=f),
-                  encoding, errors)
+    return strip(run('unrtf', '--text', '--nopict', stdin=f),
+                 encoding, errors)
 
 
 def handle_path(path, **kwargs):
     encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return _strip(run('unrtf', '--text', '--nopict', path),
-                  encoding, errors)
+    return strip(run('unrtf', '--text', '--nopict', path),
+                 encoding, errors)

--- a/fulltext/backends/__xml.py
+++ b/fulltext/backends/__xml.py
@@ -8,7 +8,7 @@ from six import StringIO
 from six import PY3
 
 
-def _is_visible(elem, encoding, errors):
+def is_visible(elem, encoding, errors):
     if isinstance(elem, (bs4.element.ProcessingInstruction,
                          bs4.element.Doctype)):
         return False
@@ -28,7 +28,7 @@ def handle_fobj(f, **kwargs):
     text, bs = StringIO(), bs4.BeautifulSoup(tdata, 'lxml')
 
     for elem in bs.findAll(text=True):
-        if _is_visible(elem, encoding, errors):
+        if is_visible(elem, encoding, errors):
             text.write(elem)
             text.write(u' ')
 


### PR DESCRIPTION
Not sure if it is desirable but since we dropped `_` in `__init__` (which is "public") I suppose we can also do the same in backend modules which are already private (has double underscore).