### PR TITLE
Encapsulate backends logic into a class

### DIFF
--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -473,11 +473,6 @@ def get(path_or_file, default=SENTINAL, mime=None, name=None, backend=None,
     if encoding_errors is None:
         encoding_errors = ENCODING_ERRORS
 
-    kwargs = kwargs.copy() if kwargs is not None else {}
-    kwargs.setdefault("mime", mime)
-    kwargs["encoding"] = encoding
-    kwargs["encoding_errors"] = encoding_errors
-
     try:
         return _get(path_or_file, default=default, mime=mime, name=name,
                     backend=backend, kwargs=kwargs, encoding=encoding,

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -352,8 +352,8 @@ def backend_from_fobj(f):
             f.seek(offset)
 
 
-def backend_inst_from_mod(mod, mime, encoding, encoding_errors, kwargs):
-    kw = dict(mime=mime, encoding=encoding, encoding_errors=encoding_errors,
+def backend_inst_from_mod(mod, encoding, encoding_errors, kwargs):
+    kw = dict(encoding=encoding, encoding_errors=encoding_errors,
               kwargs=kwargs)
     try:
         klass = getattr(mod, "Backend")
@@ -379,9 +379,8 @@ def backend_inst_from_mod(mod, mime, encoding, encoding_errors, kwargs):
 class BaseBackend(object):
     """Base class for defining custom backend classes."""
 
-    def __init__(self, mime, encoding, encoding_errors, kwargs):
+    def __init__(self, encoding, encoding_errors, kwargs):
         """These are the same args passed to get() function."""
-        self.mime = mime
         self.encoding = encoding
         self.encoding_errors = encoding_errors
         self.kwargs = kwargs
@@ -438,7 +437,7 @@ def _get(path_or_file, default, mime, name, backend, encoding,
 
     # Call backend.
     inst = backend_inst_from_mod(
-        backend_mod, mime, encoding, encoding_errors, kwargs)
+        backend_mod, encoding, encoding_errors, kwargs)
     fun = handle_path if is_file_path(path_or_file) else handle_fobj
     try:
         text = fun(inst, path_or_file)
@@ -472,6 +471,9 @@ def get(path_or_file, default=SENTINAL, mime=None, name=None, backend=None,
         encoding = ENCODING
     if encoding_errors is None:
         encoding_errors = ENCODING_ERRORS
+
+    kwargs = kwargs.copy() if kwargs is not None else {}
+    kwargs.setdefault("mime", mime)
 
     try:
         return _get(path_or_file, default=default, mime=mime, name=name,

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -352,8 +352,9 @@ def backend_from_fobj(f):
             f.seek(offset)
 
 
-def backend_inst_from_mod(mod, mime, encoding, encoding_errors):
-    kw = dict(mime=mime, encoding=encoding, encoding_errors=encoding_errors)
+def backend_inst_from_mod(mod, mime, encoding, encoding_errors, kwargs):
+    kw = dict(mime=mime, encoding=encoding, encoding_errors=encoding_errors,
+              kwargs=kwargs)
     try:
         klass = getattr(mod, "Backend")
     except AttributeError:
@@ -436,7 +437,8 @@ def _get(path_or_file, default, mime, name, backend, encoding,
             backend_mod = backend
 
     # Call backend.
-    inst = backend_inst_from_mod(backend_mod, mime, encoding, encoding_errors)
+    inst = backend_inst_from_mod(
+        backend_mod, mime, encoding, encoding_errors, kwargs)
     fun = handle_path if is_file_path(path_or_file) else handle_fobj
     try:
         text = fun(inst, path_or_file)

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -367,7 +367,6 @@ def backend_inst_from_mod(mod, encoding, encoding_errors, kwargs):
         warn("can't use %r due to %r; use %r backend instead" % (
              mod, str(err), bin_mod))
         inst = import_mod(bin_mod).Backend(**kw)
-    inst.setup()
     return inst
 
 
@@ -435,14 +434,18 @@ def _get(path_or_file, default, mime, name, backend, encoding,
         else:
             backend_mod = backend
 
-    # Call backend.
+    # Get backend class.
     inst = backend_inst_from_mod(
         backend_mod, encoding, encoding_errors, kwargs)
     fun = handle_path if is_file_path(path_or_file) else handle_fobj
+
+    # Run handle_ function, handle callbacks.
+    inst.setup()
     try:
         text = fun(inst, path_or_file)
     finally:
         inst.teardown()
+
     assert text is not None, "backend function returned None"
     text = STRIP_WHITE.sub(' ', text)
     return text.strip()

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -353,6 +353,9 @@ def backend_from_fobj(f):
 
 
 def backend_inst_from_mod(mod, encoding, encoding_errors, kwargs):
+    """Given a mod and a set of opts return an instantiated
+    Backend class.
+    """
     kw = dict(encoding=encoding, encoding_errors=encoding_errors,
               kwargs=kwargs)
     try:
@@ -367,6 +370,7 @@ def backend_inst_from_mod(mod, encoding, encoding_errors, kwargs):
         warn("can't use %r due to %r; use %r backend instead" % (
              mod, str(err), bin_mod))
         inst = import_mod(bin_mod).Backend(**kw)
+        inst.check()
     return inst
 
 

--- a/fulltext/__main__.py
+++ b/fulltext/__main__.py
@@ -33,15 +33,21 @@ def check_backends():
             continue
         mod_name = "fulltext.backends.%s" % (
             os.path.splitext(os.path.basename(name))[0])
-        mod = __import__(mod_name, fromlist=[' '])
+
+        try:
+            mod = __import__(mod_name, fromlist=[' '])
+        except ImportError as err:
+            errs.append((mod_name, str(err)))
+            continue
+
         if hasattr(mod, "check"):
             try:
                 mod.check()
             except Exception as err:
-                errs.append((mod, str(err)))
+                errs.append((mod.__name__, str(err)))
     if errs:
         for mod, err in errs:
-            msg = hilite("%s: %s" % (mod.__name__, err), ok=False)
+            msg = hilite("%s: %s" % (mod, err), ok=False)
             print(msg, file=sys.stderr)
         sys.exit(1)
 

--- a/fulltext/backends/__bin.py
+++ b/fulltext/backends/__bin.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     maketrans = bytes.maketrans
 
+from fulltext import BaseBackend
+
 
 BUFFER_MAX = 1024 * 1024
 
@@ -32,22 +34,24 @@ STRIP_PUNCTUATION = re.compile(
     r'|}~0-9])[^\w]*\b')
 
 
-def handle_fobj(f, **kwargs):
-    buffer = StringIO()
+class Backend(BaseBackend):
 
-    while True:
-        text = f.read(BUFFER_MAX)
+    def handle_fobj(self, f):
+        buffer = StringIO()
 
-        if not text:
-            break
+        while True:
+            text = f.read(BUFFER_MAX)
 
-        # Emulate the `strings` CLI tool.
-        text = text.translate(TRANSLATE)
-        text = text.decode('ascii', 'ignore')
+            if not text:
+                break
 
-        # Remove any "words" that consist mainly of punctuation.
-        text = STRIP_PUNCTUATION.sub(' ', text)
+            # Emulate the `strings` CLI tool.
+            text = text.translate(TRANSLATE)
+            text = text.decode('ascii', 'ignore')
 
-        buffer.write(text)
+            # Remove any "words" that consist mainly of punctuation.
+            text = STRIP_PUNCTUATION.sub(' ', text)
 
-    return buffer.getvalue()
+            buffer.write(text)
+
+        return buffer.getvalue()

--- a/fulltext/backends/__csv.py
+++ b/fulltext/backends/__csv.py
@@ -8,22 +8,21 @@ from six import PY3
 from fulltext import BaseBackend
 
 
-if PY3:
-    def unicode_reader(f, encoding, encoding_errors, **opts):
-        def readlines(f):
-            for line in f.readlines():
-                yield line.decode(encoding, encoding_errors)
-
-        return csv.reader(readlines(f), **opts)
-else:
-    def unicode_reader(f, encoding, encoding_errors, **opts):
-        reader = csv.reader(f, **opts)
-        for row in reader:
-            yield [unicode(cell, encoding, encoding_errors)  # NOQA
-                   for cell in row]
-
-
 class Backend(BaseBackend):
+
+    if PY3:
+        def unicode_reader(self, f, **opts):
+            def readlines(f):
+                for line in f.readlines():
+                    yield line.decode(self.encoding, self.encoding_errors)
+
+            return csv.reader(readlines(f), **opts)
+    else:
+        def unicode_reader(self, f, **opts):
+            reader = csv.reader(f, **opts)
+            for row in reader:
+                yield [unicode(cell, self.encoding, self.encoding_errors)
+                       for cell in row]
 
     def handle_fobj(self, f):
         options = {
@@ -40,7 +39,7 @@ class Backend(BaseBackend):
             options['delimiter'] = '|'
 
         text = StringIO()
-        reader = unicode_reader(
+        reader = self.unicode_reader(
             f, self.encoding, self.encoding_errors, **options)
         for row in reader:
             text.write(u' '.join(row))

--- a/fulltext/backends/__csv.py
+++ b/fulltext/backends/__csv.py
@@ -21,7 +21,7 @@ class Backend(BaseBackend):
         def unicode_reader(self, f, **opts):
             reader = csv.reader(f, **opts)
             for row in reader:
-                yield [unicode(cell, self.encoding, self.encoding_errors)
+                yield [unicode(cell, self.encoding, self.encoding_errors)  # NOQA
                        for cell in row]
 
     def handle_fobj(self, f):

--- a/fulltext/backends/__csv.py
+++ b/fulltext/backends/__csv.py
@@ -39,8 +39,7 @@ class Backend(BaseBackend):
             options['delimiter'] = '|'
 
         text = StringIO()
-        reader = self.unicode_reader(
-            f, self.encoding, self.encoding_errors, **options)
+        reader = self.unicode_reader(f, **options)
         for row in reader:
             text.write(u' '.join(row))
             text.write(u'\n')

--- a/fulltext/backends/__csv.py
+++ b/fulltext/backends/__csv.py
@@ -5,6 +5,8 @@ import csv
 from six import StringIO
 from six import PY3
 
+from fulltext import BaseBackend
+
 
 if PY3:
     def unicode_reader(f, encoding, encoding_errors, **opts):
@@ -21,25 +23,27 @@ else:
                    for cell in row]
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    options = {
-        'dialect': 'excel',
-        'delimiter': ',',
-    }
+class Backend(BaseBackend):
 
-    mimetype = kwargs.get('mime', None)
+    def handle_fobj(self, f):
+        options = {
+            'dialect': 'excel',
+            'delimiter': ',',
+        }
 
-    if mimetype == 'text/tsv':
-        options['delimiter'] = '\t'
+        mimetype = self.kwargs.get('mime', None)
 
-    elif mimetype == 'text/psv':
-        options['delimiter'] = '|'
+        if mimetype == 'text/tsv':
+            options['delimiter'] = '\t'
 
-    text = StringIO()
-    reader = unicode_reader(f, encoding, errors, **options)
-    for row in reader:
-        text.write(u' '.join(row))
-        text.write(u'\n')
+        elif mimetype == 'text/psv':
+            options['delimiter'] = '|'
 
-    return text.getvalue()
+        text = StringIO()
+        reader = unicode_reader(
+            f, self.encoding, self.encoding_errors, **options)
+        for row in reader:
+            text.write(u' '.join(row))
+            text.write(u'\n')
+
+        return text.getvalue()

--- a/fulltext/backends/__doc.py
+++ b/fulltext/backends/__doc.py
@@ -4,47 +4,46 @@ import logging
 
 from fulltext.util import run, ShellError, MissingCommandException
 from fulltext.util import assert_cmd_exists
-
-
-def check():
-    assert_cmd_exists('antiword')
-    assert_cmd_exists('abiword')
+from fulltext import BaseBackend
 
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    try:
-        return run('antiword', '-', stdin=f).decode(encoding, errors)
-    except ShellError as e:
-        if b'not a Word Document' not in e.stderr:
-            raise
-        LOGGER.warning('.doc file unsupported format, trying abiword')
-    except MissingCommandException:
-        LOGGER.warning('CLI tool "antiword" missing, using "abiword"')
+class Backend(BaseBackend):
 
-    f.seek(0)
+    def check(self):
+        assert_cmd_exists('antiword')
+        assert_cmd_exists('abiword')
 
-    # Try abiword, slower, but supports more formats.
-    return run(
-        'abiword', '--to=txt', '--to-name=fd://1', 'fd://0', stdin=f
-    ).decode(encoding, errors)
+    def handle_fobj(self, f):
+        try:
+            return self.decode(run('antiword', '-', stdin=f))
+        except ShellError as e:
+            if b'not a Word Document' not in e.stderr:
+                raise
+            LOGGER.warning('.doc file unsupported format, trying abiword')
+        except MissingCommandException:
+            LOGGER.warning('CLI tool "antiword" missing, using "abiword"')
 
+        f.seek(0)
 
-def handle_path(path, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    try:
-        return run('antiword', path).decode(encoding, errors)
-    except ShellError as e:
-        if b'not a Word Document' not in e.stderr:
-            raise
-        LOGGER.warning('.doc file unsupported format, trying abiword')
-    except MissingCommandException:
-        LOGGER.warning('CLI tool "antiword" missing, using "abiword"')
+        # Try abiword, slower, but supports more formats.
+        return self.decode(run(
+            'abiword', '--to=txt', '--to-name=fd://1', 'fd://0', stdin=f
+        ))
 
-    # Try abiword, slower, but supports more formats.
-    return run('abiword', '--to=txt', '--to-name=fd://1', path).decode(
-        encoding, errors)
+    def handle_path(self, path):
+        try:
+            return self.decode(run('antiword', path))
+        except ShellError as e:
+            if b'not a Word Document' not in e.stderr:
+                raise
+            LOGGER.warning('.doc file unsupported format, trying abiword')
+        except MissingCommandException:
+            LOGGER.warning('CLI tool "antiword" missing, using "abiword"')
+
+        # Try abiword, slower, but supports more formats.
+        return self.decode(
+            run('abiword', '--to=txt', '--to-name=fd://1', path))

--- a/fulltext/backends/__docx.py
+++ b/fulltext/backends/__docx.py
@@ -1,10 +1,12 @@
 import docx2txt
+from fulltext import BaseBackend
 
 
-# Note: docx2txt does not support encoding.
-def handle_fobj(path_or_file, **kwargs):
-    return docx2txt.process(path_or_file)
+class Backend(BaseBackend):
 
+    # Note: docx2txt does not support encoding.
+    def handle_fobj(self, path_or_file):
+        return docx2txt.process(path_or_file)
 
-# They are equivalent, process() uses zipfile.ZipFile().
-handle_path = handle_fobj
+    # They are equivalent, process() uses zipfile.ZipFile().
+    handle_path = handle_fobj

--- a/fulltext/backends/__eml.py
+++ b/fulltext/backends/__eml.py
@@ -9,8 +9,8 @@ from fulltext import BaseBackend
 # This is used by other modules, hence it's here.
 def handle_fobj(f, encoding, errors):
     text = StringIO()
-    f2 = codecs.getreader(encoding)(f, errors=errors)
-    m = message_from_file(f2)
+    encf = codecs.getreader(encoding)(f, errors=errors)
+    m = message_from_file(encf)
 
     for part in m.walk():
         if part.get_content_type().startswith('text/plain'):

--- a/fulltext/backends/__eml.py
+++ b/fulltext/backends/__eml.py
@@ -6,6 +6,7 @@ from six import StringIO
 from fulltext import BaseBackend
 
 
+# This is used by other modules, hence it's here.
 def handle_fobj(f, encoding, errors):
     text = StringIO()
     f2 = codecs.getreader(encoding)(f, errors=errors)

--- a/fulltext/backends/__eml.py
+++ b/fulltext/backends/__eml.py
@@ -3,10 +3,10 @@ from email import message_from_file
 import codecs
 
 from six import StringIO
+from fulltext import BaseBackend
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
+def handle_fobj(f, encoding, errors):
     text = StringIO()
     f2 = codecs.getreader(encoding)(f, errors=errors)
     m = message_from_file(f2)
@@ -16,3 +16,9 @@ def handle_fobj(f, **kwargs):
             text.write(part.get_payload())
 
     return text.getvalue()
+
+
+class Backend(BaseBackend):
+
+    def handle_fobj(self, f):
+        return handle_fobj(f, self.encoding, self.encoding_errors)

--- a/fulltext/backends/__epub.py
+++ b/fulltext/backends/__epub.py
@@ -4,20 +4,23 @@
 from ebooklib import epub
 
 from bs4 import BeautifulSoup
-
 from six import StringIO
 
+from fulltext import BaseBackend
 
-def handle_path(path, **kwargs):
-    text, book = StringIO(), epub.read_epub(path)
 
-    for id, _ in book.spine:
-        item = book.get_item_with_id(id)
-        soup = BeautifulSoup(item.content, 'lxml')
-        for child in soup.find_all(
-            ['title', 'p', 'div', 'h1', 'h2', 'h3', 'h4']
-        ):
-            text.write(child.text)
-            text.write(u'\n')
+class Backend(BaseBackend):
 
-    return text.getvalue()
+    def handle_path(self, path):
+        text, book = StringIO(), epub.read_epub(path)
+
+        for id, _ in book.spine:
+            item = book.get_item_with_id(id)
+            soup = BeautifulSoup(item.content, 'lxml')
+            for child in soup.find_all(
+                ['title', 'p', 'div', 'h1', 'h2', 'h3', 'h4']
+            ):
+                text.write(child.text)
+                text.write(u'\n')
+
+        return text.getvalue()

--- a/fulltext/backends/__gz.py
+++ b/fulltext/backends/__gz.py
@@ -2,6 +2,7 @@ import gzip
 from os.path import splitext, basename
 
 from fulltext import get, backend_from_fname, backend_from_fobj, is_file_path
+from fulltext import BaseBackend
 
 
 def orig_fname(s):
@@ -15,21 +16,22 @@ def _has_ext(s):
     return bool(splitext(s)[1])
 
 
-def handle_fobj(path_or_file, **kwargs):
-    if is_file_path(path_or_file):
-        f = gzip.GzipFile(path_or_file)
-        path = path_or_file
-    else:
-        f = gzip.GzipFile(fileobj=path_or_file)
-        path = f.name
+class Backend(BaseBackend):
 
-    with f:
-        orig_name = orig_fname(path)
-        if _has_ext(orig_name) and splitext(orig_name)[1].lower() != '.gz':
-            backend = backend_from_fname(orig_name)
+    def handle_fobj(self, path_or_file):
+        if is_file_path(path_or_file):
+            f = gzip.GzipFile(path_or_file)
+            path = path_or_file
         else:
-            backend = backend_from_fobj(f)
-        return get(f, backend=backend)
+            f = gzip.GzipFile(fileobj=path_or_file)
+            path = f.name
 
+        with f:
+            orig_name = orig_fname(path)
+            if _has_ext(orig_name) and splitext(orig_name)[1].lower() != '.gz':
+                backend = backend_from_fname(orig_name)
+            else:
+                backend = backend_from_fobj(f)
+            return get(f, backend=backend)
 
-handle_path = handle_fobj
+    handle_path = handle_fobj

--- a/fulltext/backends/__html.py
+++ b/fulltext/backends/__html.py
@@ -7,28 +7,30 @@ from bs4 import BeautifulSoup
 from six import StringIO
 from six import PY3
 
-
-def is_visible(elem, encoding, errors):
-    if elem.parent.name in ['style', 'script', '[document]', 'head']:
-        return False
-
-    if not PY3:
-        elem = elem.encode(encoding, errors)
-    if re.match('<!--.*-->', elem):
-        return False
-
-    return True
+from fulltext import BaseBackend
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    data = f.read()
-    data = data.decode(encoding, errors)
-    text, bs = StringIO(), BeautifulSoup(data, 'lxml')
+class Backend(BaseBackend):
 
-    for elem in bs.findAll(text=True):
-        if is_visible(elem, encoding, errors):
-            text.write(elem)
-            text.write(u' ')
+    def is_visible(self, elem):
+        if elem.parent.name in ['style', 'script', '[document]', 'head']:
+            return False
 
-    return text.getvalue()
+        if not PY3:
+            elem = elem.encode(self.encoding, self.encoding_errors)
+        if re.match('<!--.*-->', elem):
+            return False
+
+        return True
+
+    def handle_fobj(self, f):
+        data = f.read()
+        data = self.decode(data)
+        text, bs = StringIO(), BeautifulSoup(data, 'lxml')
+
+        for elem in bs.findAll(text=True):
+            if self.is_visible(elem):
+                text.write(elem)
+                text.write(u' ')
+
+        return text.getvalue()

--- a/fulltext/backends/__hwp.py
+++ b/fulltext/backends/__hwp.py
@@ -2,10 +2,7 @@ from __future__ import absolute_import
 
 from fulltext.backends import __html
 from fulltext.util import run, assert_cmd_exists
-
-
-def check():
-    assert_cmd_exists('hwp5proc')
+from fulltext import BaseBackend
 
 
 def cmd(path, **kwargs):
@@ -18,7 +15,11 @@ def to_text_with_backend(html):
     return __html.handle_fobj(html)
 
 
-def handle_path(path, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return to_text_with_backend(run(*cmd(path, **kwargs)).decode(
-        encoding, errors))
+class Backend(BaseBackend):
+
+    def check(self):
+        assert_cmd_exists('hwp5proc')
+
+    def handle_path(self, path):
+        out = self.decode(run(*cmd(path)))
+        return to_text_with_backend(out)

--- a/fulltext/backends/__json.py
+++ b/fulltext/backends/__json.py
@@ -4,6 +4,7 @@ import sys
 from six import StringIO
 from six import string_types
 from six import integer_types
+from fulltext import BaseBackend
 
 
 SCALAR_TYPES = string_types + integer_types
@@ -27,13 +28,14 @@ def to_text(text, obj):
         raise ValueError('Unrecognized type: %s' % obj.__class__)
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    text, data = StringIO(), f.read()
+class Backend(BaseBackend):
 
-    # TODO: catch exception and attempt to use regex to strip formatting.
-    obj = json.loads(data.decode(encoding, errors))
+    def handle_fobj(self, f):
+        text, data = StringIO(), f.read()
 
-    to_text(text, obj)
+        # TODO: catch exception and attempt to use regex to strip formatting.
+        obj = json.loads(self.decode(data))
 
-    return text.getvalue()
+        to_text(text, obj)
+
+        return text.getvalue()

--- a/fulltext/backends/__mbox.py
+++ b/fulltext/backends/__mbox.py
@@ -4,13 +4,18 @@ import mailbox
 from six import StringIO
 
 from fulltext.backends.__eml import handle_fobj
+from fulltext import BaseBackend
 
 
-def handle_path(path, **kwargs):
-    text, mb = StringIO(), mailbox.mbox(path, create=False)
-    with contextlib.closing(mb):
-        for k in mb.keys():
-            text.write(handle_fobj(mb.get_file(k), **kwargs))
-            text.write(u'\n\n')
+class Backend(BaseBackend):
 
-    return text.getvalue()
+    def handle_path(self, path):
+        text, mb = StringIO(), mailbox.mbox(path, create=False)
+        with contextlib.closing(mb):
+            for k in mb.keys():
+                t = handle_fobj(mb.get_file(k), self.encoding,
+                                self.encoding_errors)
+                text.write(t)
+                text.write(u'\n\n')
+
+        return text.getvalue()

--- a/fulltext/backends/__msg.py
+++ b/fulltext/backends/__msg.py
@@ -1,13 +1,16 @@
 from six import StringIO
 
 from ExtractMsg import Message
+from fulltext import BaseBackend
 
 
-def handle_path(path, **kwargs):
-    text, m = StringIO(), Message(path)
+class Backend(BaseBackend):
 
-    text.write(m.subject)
-    text.write(u'\n\n')
-    text.write(m.body)
+    def handle_path(self, path):
+        text, m = StringIO(), Message(path)
 
-    return text.getvalue()
+        text.write(m.subject)
+        text.write(u'\n\n')
+        text.write(m.body)
+
+        return text.getvalue()

--- a/fulltext/backends/__ocr.py
+++ b/fulltext/backends/__ocr.py
@@ -9,6 +9,7 @@ from PIL import Image
 import pytesseract
 
 from fulltext.util import assert_cmd_exists, MissingCommandException
+from fulltext import BaseBackend
 
 
 EXIF_ORIENTATION = 274  # cf ExifTags
@@ -17,10 +18,6 @@ EXIF_ROTATION = {
     6: 270,
     8: 90
 }
-
-
-def check():
-    assert_cmd_exists('tesseract')
 
 
 def read(img, **kargs):
@@ -52,8 +49,12 @@ def read(img, **kargs):
         raise
 
 
-def handle_fobj(path_or_file, **kwargs):
-    return read(path_or_file, **kwargs)
+class Backend(BaseBackend):
 
+    def check(self):
+        assert_cmd_exists('tesseract')
 
-handle_path = handle_fobj
+    def handle_fobj(self, path_or_file):
+        return read(path_or_file, **self.kwargs)
+
+    handle_path = handle_fobj

--- a/fulltext/backends/__odt.py
+++ b/fulltext/backends/__odt.py
@@ -5,6 +5,8 @@ from lxml import etree
 
 from six import StringIO
 
+from fulltext import BaseBackend
+
 
 def qn(ns):
     nsmap = {
@@ -29,18 +31,19 @@ def to_string(text, elem):
     text.write(u'\n')
 
 
-def handle_fobj(f, **kwargs):
-    text = StringIO()
+class Backend(BaseBackend):
 
-    with zipfile.ZipFile(f, 'r') as z:
-        with z.open('content.xml', 'r') as c:
-            xml = etree.parse(c)
+    def handle_fobj(self, f):
+        text = StringIO()
 
-            for c in xml.iter():
-                if c.tag in (qn('text:p'), qn('text:h')):
-                    to_string(text, c)
+        with zipfile.ZipFile(f, 'r') as z:
+            with z.open('content.xml', 'r') as c:
+                xml = etree.parse(c)
 
-    return text.getvalue()
+                for c in xml.iter():
+                    if c.tag in (qn('text:p'), qn('text:h')):
+                        to_string(text, c)
 
+        return text.getvalue()
 
-handle_path = handle_fobj
+    handle_path = handle_fobj

--- a/fulltext/backends/__pdf.py
+++ b/fulltext/backends/__pdf.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 from fulltext.util import run, assert_cmd_exists
-
-
-def check():
-    assert_cmd_exists('pdftotext')
+from fulltext import BaseBackend
 
 
 def cmd(path, **kwargs):
@@ -17,11 +14,15 @@ def cmd(path, **kwargs):
     return cmd
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return run(*cmd('-', **kwargs), stdin=f).decode(encoding, errors)
+class Backend(BaseBackend):
 
+    def handle_fobj(self, f):
+        out = run(*cmd('-', **self.kwargs), stdin=f)
+        return self.decode(out)
 
-def handle_path(path, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return run(*cmd(path, **kwargs)).decode(encoding, errors)
+    def handle_path(self, path):
+        out = run(*cmd(path, **self.kwargs))
+        return self.decode(out)
+
+    def check(self):
+        assert_cmd_exists('pdftotext')

--- a/fulltext/backends/__pdf.py
+++ b/fulltext/backends/__pdf.py
@@ -16,6 +16,9 @@ def cmd(path, **kwargs):
 
 class Backend(BaseBackend):
 
+    def check(self):
+        assert_cmd_exists('pdftotext')
+
     def handle_fobj(self, f):
         out = run(*cmd('-', **self.kwargs), stdin=f)
         return self.decode(out)
@@ -23,6 +26,3 @@ class Backend(BaseBackend):
     def handle_path(self, path):
         out = run(*cmd(path, **self.kwargs))
         return self.decode(out)
-
-    def check(self):
-        assert_cmd_exists('pdftotext')

--- a/fulltext/backends/__pptx.py
+++ b/fulltext/backends/__pptx.py
@@ -3,16 +3,19 @@ from __future__ import absolute_import
 import pptx
 
 from six import StringIO
+from fulltext import BaseBackend
 
 
-def handle_path(path, **kwargs):
-    text, p = StringIO(), pptx.Presentation(path)
-    for slide in p.slides:
-        for shape in slide.shapes:
-            if not shape.has_text_frame:
-                continue
-            for para in shape.text_frame.paragraphs:
-                for run in para.runs:
-                    text.write(run.text)
-                    text.write(u'\n\n')
-    return text.getvalue()
+class Backend(BaseBackend):
+
+    def handle_path(self, path):
+        text, p = StringIO(), pptx.Presentation(path)
+        for slide in p.slides:
+            for shape in slide.shapes:
+                if not shape.has_text_frame:
+                    continue
+                for para in shape.text_frame.paragraphs:
+                    for run in para.runs:
+                        text.write(run.text)
+                        text.write(u'\n\n')
+        return text.getvalue()

--- a/fulltext/backends/__ps.py
+++ b/fulltext/backends/__ps.py
@@ -3,17 +3,18 @@
 
 from __future__ import absolute_import
 from fulltext.util import run, assert_cmd_exists
+from fulltext import BaseBackend
 
 
-def check():
-    assert_cmd_exists('pstotext')
+class Backend(BaseBackend):
 
+    def check(self):
+        assert_cmd_exists('pstotext')
 
-def handle_fobj(f, **kwargs):
-    out = run('pstotext', '-', stdin=f)
-    return out.decode(kwargs['encoding'], kwargs['encoding_errors'])
+    def handle_fobj(self, f):
+        out = run('pstotext', '-', stdin=f)
+        return self.decode(out)
 
-
-def handle_path(path, **kwargs):
-    out = run('pstotext', path)
-    return out.decode(kwargs['encoding'], kwargs['encoding_errors'])
+    def handle_path(self, path):
+        out = run('pstotext', path)
+        return self.decode(out)

--- a/fulltext/backends/__rtf.py
+++ b/fulltext/backends/__rtf.py
@@ -1,23 +1,24 @@
 from __future__ import absolute_import
 from fulltext.util import run
 from fulltext.util import assert_cmd_exists
-
-
-def check():
-    assert_cmd_exists('unrtf')
+from fulltext import BaseBackend
 
 
 def strip(text, encoding, errors):
     return text.partition(b'-----------------')[2].decode(encoding, errors)
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return strip(run('unrtf', '--text', '--nopict', stdin=f),
-                 encoding, errors)
+class Backend(BaseBackend):
 
+    def check(self):
+        assert_cmd_exists('unrtf')
 
-def handle_path(path, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    return strip(run('unrtf', '--text', '--nopict', path),
-                 encoding, errors)
+    def handle_fobj(self, f):
+        encoding, errors = self.encoding, self.encoding_errors
+        return strip(run('unrtf', '--text', '--nopict', stdin=f),
+                     encoding, errors)
+
+    def handle_path(self, path):
+        encoding, errors = self.encoding, self.encoding_errors
+        return strip(run('unrtf', '--text', '--nopict', path),
+                     encoding, errors)

--- a/fulltext/backends/__rtf.py
+++ b/fulltext/backends/__rtf.py
@@ -4,21 +4,18 @@ from fulltext.util import assert_cmd_exists
 from fulltext import BaseBackend
 
 
-def strip(text, encoding, errors):
-    return text.partition(b'-----------------')[2].decode(encoding, errors)
-
-
 class Backend(BaseBackend):
 
     def check(self):
         assert_cmd_exists('unrtf')
 
+    def strip(self, text):
+        return self.decode(text.partition(b'-----------------')[2])
+
     def handle_fobj(self, f):
-        encoding, errors = self.encoding, self.encoding_errors
-        return strip(run('unrtf', '--text', '--nopict', stdin=f),
-                     encoding, errors)
+        return self.strip(
+            run('unrtf', '--text', '--nopict', stdin=f))
 
     def handle_path(self, path):
-        encoding, errors = self.encoding, self.encoding_errors
-        return strip(run('unrtf', '--text', '--nopict', path),
-                     encoding, errors)
+        return self.strip(
+            run('unrtf', '--text', '--nopict', path))

--- a/fulltext/backends/__text.py
+++ b/fulltext/backends/__text.py
@@ -11,24 +11,26 @@ Any decoding issues are ignored.
 from __future__ import absolute_import
 
 from six import StringIO
+from fulltext import BaseBackend
 
 
 BUFFER_MAX = 1024 * 1024
 
 
-def handle_fobj(f, **kwargs):
-    encoding, errors = kwargs['encoding'], kwargs['encoding_errors']
-    buffer = StringIO()
+class Backend(BaseBackend):
 
-    while True:
-        text = f.read(BUFFER_MAX)
+    def handle_fobj(self, f):
+        buffer = StringIO()
 
-        if not text:
-            break
+        while True:
+            text = f.read(BUFFER_MAX)
 
-        text = text.decode(encoding, errors)
+            if not text:
+                break
 
-        # Emulate the `strings` CLI tool.
-        buffer.write(text)
+            text = self.decode(text)
 
-    return buffer.getvalue()
+            # Emulate the `strings` CLI tool.
+            buffer.write(text)
+
+        return buffer.getvalue()

--- a/fulltext/backends/__xlsx.py
+++ b/fulltext/backends/__xlsx.py
@@ -4,19 +4,23 @@ import xlrd
 
 from six import StringIO
 
+from fulltext import BaseBackend
 
-def handle_path(path, **kwargs):
-    text = StringIO()
-    wb = xlrd.open_workbook(path)
-    for n in wb.sheet_names():
-        ws = wb.sheet_by_name(n)
-        for x in range(ws.nrows):
-            for y in range(ws.ncols):
-                v = ws.cell_value(x, y)
-                if v:
-                    if isinstance(v, (int, float)):
-                        v = str(v)
-                    text.write(v)
-                    text.write(u' ')
-            text.write(u'\n')
-    return text.getvalue()
+
+class Backend(BaseBackend):
+
+    def handle_path(self, path):
+        text = StringIO()
+        wb = xlrd.open_workbook(path)
+        for n in wb.sheet_names():
+            ws = wb.sheet_by_name(n)
+            for x in range(ws.nrows):
+                for y in range(ws.ncols):
+                    v = ws.cell_value(x, y)
+                    if v:
+                        if isinstance(v, (int, float)):
+                            v = str(v)
+                        text.write(v)
+                        text.write(u' ')
+                text.write(u'\n')
+        return text.getvalue()

--- a/fulltext/backends/__zip.py
+++ b/fulltext/backends/__zip.py
@@ -5,22 +5,23 @@ import zipfile
 from six import StringIO
 from contextlib2 import ExitStack
 
-from fulltext import get
+from fulltext import BaseBackend, get
 
 
-def handle_fobj(f, **kwargs):
-    with ExitStack() as stack:
-        text = StringIO()
-        z = stack.enter_context(zipfile.ZipFile(f, 'r'))
-        for name in sorted(z.namelist()):
-            zf = stack.enter_context(z.open(name, 'r'))
-            # Kinda hacky, but zipfile's open() does not handle "b" in
-            # the mode.
-            # We do this here to satisy an assertion in handle_fobj().
-            zf.mode += 'b'
-            text.write(get(zf, name=name))
+class Backend(BaseBackend):
 
-        return text.getvalue()
+    def handle_fobj(self, f):
+        with ExitStack() as stack:
+            text = StringIO()
+            z = stack.enter_context(zipfile.ZipFile(f, 'r'))
+            for name in sorted(z.namelist()):
+                zf = stack.enter_context(z.open(name, 'r'))
+                # Kinda hacky, but zipfile's open() does not handle "b" in
+                # the mode.
+                # We do this here to satisy an assertion in handle_fobj().
+                zf.mode += 'b'
+                text.write(get(zf, name=name))
 
+            return text.getvalue()
 
-handle_path = handle_fobj
+    handle_path = handle_fobj

--- a/tests.py
+++ b/tests.py
@@ -183,6 +183,22 @@ class TestCLI(BaseTestCase):
     #                           shell=True)
 
 
+class TestBackendInterface(BaseTestCase):
+
+    def test_params(self):
+        # Make sure Backend class receives the right params.
+        fname = self.touch('testfn.doc')
+        with mock.patch('fulltext.handle_path', return_value="") as m:
+            fulltext.get(fname,
+                         mime='application/zip',
+                         encoding='foo',
+                         encoding_errors='bar')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.mime, 'application/zip')
+            self.assertEqual(klass.encoding, 'foo')
+            self.assertEqual(klass.encoding_errors, 'bar')
+
+
 # --- Mixin tests
 
 

--- a/tests.py
+++ b/tests.py
@@ -488,16 +488,16 @@ class TestGuessingFromFileContent(BaseTestCase):
         self.touch(fname, content=open('files/test.pdf', 'rb').read())
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__pdf')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__pdf')
 
     def test_html(self):
         fname = "file-noext"
         self.touch(fname, content=open('files/test.html', 'rb').read())
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__html')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__html')
 
 
 class TestUtils(BaseTestCase):

--- a/tests.py
+++ b/tests.py
@@ -189,12 +189,8 @@ class TestBackendInterface(BaseTestCase):
         # Make sure Backend class receives the right params.
         fname = self.touch('testfn.doc')
         with mock.patch('fulltext.handle_path', return_value="") as m:
-            fulltext.get(fname,
-                         mime='application/zip',
-                         encoding='foo',
-                         encoding_errors='bar')
+            fulltext.get(fname, encoding='foo', encoding_errors='bar')
             klass = m.call_args[0][0]
-            self.assertEqual(klass.mime, 'application/zip')
             self.assertEqual(klass.encoding, 'foo')
             self.assertEqual(klass.encoding_errors, 'bar')
 

--- a/tests.py
+++ b/tests.py
@@ -364,24 +364,24 @@ class TestPickups(BaseTestCase):
         fname = self.touch('testfn.doc')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__doc')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__doc')
 
     def test_no_ext(self):
         # File with no extension == use bin backend.
         fname = self.touch('testfn')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__bin')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__bin')
 
     def test_unknown_ext(self):
         # File with unknown extension == use bin backend.
         fname = self.touch('testfn.unknown')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__bin')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__bin')
 
     # --- by mime opt
 
@@ -389,8 +389,8 @@ class TestPickups(BaseTestCase):
         fname = self.touch('testfn.doc')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname, mime='application/vnd.ms-excel')
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__xlsx')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__xlsx')
 
     def test_by_unknown_mime(self):
         fname = self.touch('testfn.doc')
@@ -398,8 +398,8 @@ class TestPickups(BaseTestCase):
             with warnings.catch_warnings(record=True) as ws:
                 fulltext.get(fname, mime='application/yo!')
             assert ws
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__bin')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__bin')
 
     # -- by name opt
 
@@ -407,8 +407,8 @@ class TestPickups(BaseTestCase):
         fname = self.touch('testfn')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname, name="woodstock.doc")
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__doc')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__doc')
 
     def test_by_name_with_no_ext(self):
         # Assume bin backend is picked up.
@@ -417,8 +417,8 @@ class TestPickups(BaseTestCase):
             with warnings.catch_warnings(record=True) as ws:
                 fulltext.get(fname, name=fname)
             assert ws
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__bin')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__bin')
 
     # --- by backend opt
 
@@ -427,8 +427,8 @@ class TestPickups(BaseTestCase):
         fname = self.touch('testfn.doc')
         with mock.patch('fulltext.handle_path', return_value="") as m:
             fulltext.get(fname, backend='pdf')
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__pdf')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__pdf')
 
     def test_by_invalid_backend(self):
         # Assert file ext is ignored if backend opt is used.

--- a/tests.py
+++ b/tests.py
@@ -453,8 +453,8 @@ class TestFileObj(BaseTestCase):
         f = tempfile.NamedTemporaryFile(suffix='.pdf')
         with mock.patch('fulltext.handle_fobj', return_value="") as m:
             fulltext.get(f)
-            mod = m.call_args[0][0]
-            self.assertEqual(mod.__name__, 'fulltext.backends.__pdf')
+            klass = m.call_args[0][0]
+            self.assertEqual(klass.__module__, 'fulltext.backends.__pdf')
 
     def test_fobj_offset(self):
         # Make sure offset is unaltered after guessing mime type.
@@ -523,8 +523,9 @@ class TestEncodingGeneric(BaseTestCase):
             fulltext.ENCODING_ERRORS = "bar"
             with mock.patch('fulltext.handle_path', return_value="") as m:
                 fulltext.get(fname)
-            self.assertEqual(m.call_args[1]['encoding'], 'foo')
-            self.assertEqual(m.call_args[1]['encoding_errors'], 'bar')
+                klass = m.call_args[0][0]
+                self.assertEqual(klass.encoding, 'foo')
+                self.assertEqual(klass.encoding_errors, 'bar')
         finally:
             fulltext.ENCODING = encoding
             fulltext.ENCODING_ERRORS = errors


### PR DESCRIPTION
This breaks backward compatibility. Backend modules are no longer supposed to provide certain functions. Instead they are supposed to provide a `Backend` class which inherits from `fulltext.BaseBackend`.
Each class can:

- define either `handle_fobj()` or `handle_path()` (mandatory)
- define a `check()` method which is called before `handle_*`; in case of exception a warning is printed and `bin` backend is used
- define a `setup()` method which is called before `handle_*`
- define a `teardown()` method which is called after `handle_*` (also in case of error)
- access `encoding`, `encoding_errors`, `kwargs` as class attributes (these are the ones passed to `get()` function