### PR TITLE
Fallback JSON parsing, handle missing HTML title tag.

### DIFF
--- a/fulltext/backends/__html.py
+++ b/fulltext/backends/__html.py
@@ -39,4 +39,5 @@ class Backend(BaseBackend):
         return text.getvalue()
 
     def handle_title(self, f):
-        return self.bs.title.string
+        # Title may be undefined (None), if the <title> tag is not present.
+        return getattr(self.bs.title, 'string', None)


### PR DESCRIPTION
 * If a JSON file has invalid formatting, try to recover gracefully.
 * If an HTML document is missing it's title tag, recover gracefully.