### PR TITLE
Speedup title extraction by 2x

### DIFF
--- a/fulltext/compat.py
+++ b/fulltext/compat.py
@@ -11,6 +11,12 @@ else:
     # Backport from Python 3.3.
     from contextlib2 import ExitStack  # NOQA
 
+
+POSIX = os.name == "posix"
+WINDOWS = os.name == "nt"
+LINUX = sys.platform.startswith("linux")
+
+
 try:
     from shutil import which
 except ImportError:

--- a/fulltext/util.py
+++ b/fulltext/util.py
@@ -236,17 +236,9 @@ def is_file_path(obj):
     return isinstance(obj, six.string_types) or isinstance(obj, bytes)
 
 
-try:
+if POSIX:
     import exiftool
-except ImportError:
-    if POSIX:
-        # TODO: according to https://www.sno.phy.queensu.ca/~phil/exiftool/
-        # exiftool is also available on Windows
-        raise
 
-    def exiftool_title(*a, **kw):
-        return None
-else:
     _et = exiftool.ExifTool()
     _et.start()
 
@@ -259,3 +251,9 @@ else:
             title = (_et.get_tag("title", path) or "").strip()
             if title:
                 return title.decode(encoding, encoding_error)
+
+else:
+    # TODO: according to https://www.sno.phy.queensu.ca/~phil/exiftool/
+    # exiftool is also available on Windows
+    def exiftool_title(*a, **kw):
+        return None

--- a/fulltext/util.py
+++ b/fulltext/util.py
@@ -251,7 +251,10 @@ if POSIX:
         if is_file_path(path):
             title = (_et.get_tag("title", path) or "").strip()
             if title:
-                return title.decode(encoding, encoding_error)
+                if hasattr(title, "decode"):  # PY2
+                    return title.decode(encoding, encoding_error)
+                else:
+                    return title
 
 else:
     # TODO: according to https://www.sno.phy.queensu.ca/~phil/exiftool/

--- a/fulltext/util.py
+++ b/fulltext/util.py
@@ -244,6 +244,7 @@ if POSIX:
 
     @atexit.register
     def _close_et():
+        LOGGER.debug("terminating exiftool subprocess")
         _et.terminate()
 
     def exiftool_title(path, encoding, encoding_error):

--- a/fulltext/util.py
+++ b/fulltext/util.py
@@ -1,3 +1,4 @@
+import atexit
 import errno
 import logging
 import os
@@ -10,6 +11,7 @@ from os.path import dirname, abspath
 from os.path import join as pathjoin
 
 import six
+import exiftool
 from six import PY3
 
 from fulltext.compat import which
@@ -234,9 +236,17 @@ def is_file_path(obj):
     return isinstance(obj, six.string_types) or isinstance(obj, bytes)
 
 
+et = exiftool.ExifTool()
+et.start()
+
+
+@atexit.register
+def _close_et():
+    et.terminate()
+
+
 def exiftool_title(path, encoding, encoding_error):
     if is_file_path(path):
-        bout = run("exiftool", "-title", path)
-        out = bout.decode(encoding, encoding_error)
-        if out:
-            return out[out.find(':') + 1:].strip() or None
+        title = (et.get_tag("title", path) or "").strip()
+        if title:
+            return title.decode(encoding, encoding_error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pyflakes
 python-magic
 ebooklib
 contextlib2
+mock
 
 git+https://github.com/btimby/mobi-python.git#egg=mobi
 https://github.com/mattgwwalker/msg-extractor/zipball/master

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,7 @@ pyflakes
 python-magic
 ebooklib
 contextlib2
+
 git+https://github.com/btimby/mobi-python.git#egg=mobi
 https://github.com/mattgwwalker/msg-extractor/zipball/master
+git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import unittest
 import tempfile
 import sys
 import subprocess
+import logging
 try:
     from unittest import mock  # py3
 except ImportError:
@@ -45,6 +46,8 @@ TEXT_WITH_NEWLINES = u"Lorem ipsum\ndolor sit amet, consectetur adipiscing e" \
 TEXT = TEXT_WITH_NEWLINES.replace('\n', ' ')
 WINDOWS = is_windows()
 APPVEYOR = bool(os.environ.get('APPVEYOR'))
+
+logging.basicConfig(level=logging.WARNING)
 
 
 # ===================================================================
@@ -798,6 +801,7 @@ class TestTitle(BaseTestCase):
 
     def test_doc(self):
         fname = "files/others/hello-world.doc"
+        fulltext.get_with_title(fname)
         self.assertEqual(
             fulltext.get_with_title(fname)[1], 'Lab 1: Hello World')
 


### PR DESCRIPTION
Re. #61.
Before:
```
$ python -m unittest -v tests.TestTitle
tests.TestTitle.test_doc ... ok
tests.TestTitle.test_docx ... ok
tests.TestTitle.test_epub ... ok
tests.TestTitle.test_html ... ok
tests.TestTitle.test_odt ... ok
tests.TestTitle.test_pdf ... ok
tests.TestTitle.test_pptx ... ok
tests.TestTitle.test_ps ... ok
tests.TestTitle.test_rtf ... ok
tests.TestTitle.test_xls ... ok
tests.TestTitle.test_xlsx ... ok

----------------------------------------------------------------------
Ran 11 tests in 1.665s
```
Now:
```
$ python -m unittest -v tests.TestTitle
tests.TestTitle.test_doc ... ok
tests.TestTitle.test_docx ... ok
tests.TestTitle.test_epub ... ok
tests.TestTitle.test_html ... ok
tests.TestTitle.test_odt ... ok
tests.TestTitle.test_pdf ... ok
tests.TestTitle.test_pptx ... ok
tests.TestTitle.test_ps ... ok
tests.TestTitle.test_rtf ... ok
tests.TestTitle.test_xls ... ok
tests.TestTitle.test_xlsx ... ok

----------------------------------------------------------------------
Ran 11 tests in 0.783s
```