### PR TITLE
Pyinstaller hack + fix circular imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Second, register the new backend against fulltext.
 .. code:: python
 
     import fulltext
-    from fulltext import BaseBackend
+    from fulltext.util import BaseBackend
 
 
     fulltext.register_backend(

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -486,43 +486,6 @@ def backend_inst_from_mod(mod, encoding, encoding_errors, kwargs):
 # =====================================================================
 
 
-class BaseBackend(object):
-    """Base class for defining custom backend classes."""
-
-    def __init__(self, encoding, encoding_errors, kwargs):
-        """These are the same args passed to get() function."""
-        self.encoding = encoding
-        self.encoding_errors = encoding_errors
-        self.kwargs = kwargs
-
-    def setup(self):
-        """May be overridden by subclass. This is called before handle_
-        methods.
-        """
-        pass
-
-    def teardown(self):
-        """May be overridden by subclass. This is called after text
-        is extracted, also in case of exception.
-        """
-        pass
-
-    def check(self, title):
-        """May be overridden by subclass. This is called before text
-        extraction. If the overriding method raises an exception
-        a warning is printed and bin backend is used.
-        """
-        pass
-
-    def decode(self, s):
-        """Decode string."""
-        return s.decode(self.encoding, self.encoding_errors)
-
-    def handle_title(self, path_or_file):
-        """May be overridden by sublass in order to retrieve file title."""
-        return None
-
-
 def _get(path_or_file, default, mime, name, backend, encoding,
          encoding_errors, kwargs, _wtitle):
     if encoding is None:

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -107,7 +107,6 @@ _TEXT_EXTS = set((
 # XXX: dirty hack for pyinstaller so that it includes these modules.
 # TODO: find a way to do this in pyinstaller.spec instead.
 if is_windows() and hasattr(sys, '_MEIPASS'):
-    import fulltext.util
     from fulltext.backends import __bin  # NOQA
     from fulltext.backends import __csv  # NOQA
     from fulltext.backends import __doc  # NOQA

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -104,48 +104,33 @@ _TEXT_EXTS = set((
 ))
 
 
-# Dirty hack for pyinstaller so that it includes these modules.
+# XXX: dirty hack for pyinstaller so that it includes these modules.
+# TODO: find a way to do this in pyinstaller.spec instead.
 if is_windows() and hasattr(sys, '_MEIPASS'):
-    from fulltext.backends import __msg  # NOQA
-    from fulltext.backends import __odt  # NOQA
-    from fulltext.backends import __pptx  # NOQA
+    import fulltext.util
+    from fulltext.backends import __bin  # NOQA
+    from fulltext.backends import __csv  # NOQA
+    from fulltext.backends import __doc  # NOQA
+    from fulltext.backends import __docx  # NOQA
+    from fulltext.backends import __eml  # NOQA
     from fulltext.backends import __epub  # NOQA
-    from fulltext.backends import __csv  # NOQA
-    from fulltext.backends import __ps  # NOQA
     from fulltext.backends import __gz  # NOQA
-    from fulltext.backends import __eml  # NOQA
-    from fulltext.backends import __doc  # NOQA
     from fulltext.backends import __html  # NOQA
-    from fulltext.backends import __rtf  # NOQA
-    from fulltext.backends import __mbox  # NOQA
-    from fulltext.backends import __docx  # NOQA
-    from fulltext.backends import __docx  # NOQA
-    from fulltext.backends import __doc  # NOQA
-    from fulltext.backends import __text  # NOQA
-    from fulltext.backends import __init__  # NOQA
-    from fulltext.backends import __eml  # NOQA
-    from fulltext.backends import __zip  # NOQA
-    from fulltext.backends import __html  # NOQA
-    from fulltext.backends import __gz  # NOQA
-    from fulltext.backends import __csv  # NOQA
     from fulltext.backends import __hwp  # NOQA
-    from fulltext.backends import __msg  # NOQA
-    from fulltext.backends import __bin  # NOQA
-    from fulltext.backends import __ocr  # NOQA
-    from fulltext.backends import __xml  # NOQA
-    from fulltext.backends import __xlsx  # NOQA
+    from fulltext.backends import __json  # NOQA
     from fulltext.backends import __mbox  # NOQA
-    from fulltext.backends import __json  # NOQA
-    from fulltext.backends import __pdf  # NOQA
-    from fulltext.backends import __init__  # NOQA
-    from fulltext.backends import __rar  # NOQA
-    from fulltext.backends import __json  # NOQA
-    from fulltext.backends import __epub  # NOQA
-    from fulltext.backends import __odt  # NOQA
-    from fulltext.backends import __bin  # NOQA
-    from fulltext.backends import __pdf  # NOQA
-    from fulltext.backends import __text  # NOQA
+    from fulltext.backends import __msg  # NOQA
     from fulltext.backends import __ocr  # NOQA
+    from fulltext.backends import __odt  # NOQA
+    from fulltext.backends import __pdf  # NOQA
+    from fulltext.backends import __pptx  # NOQA
+    from fulltext.backends import __ps  # NOQA
+    from fulltext.backends import __rar  # NOQA
+    from fulltext.backends import __rtf  # NOQA
+    from fulltext.backends import __text  # NOQA
+    from fulltext.backends import __xlsx  # NOQA
+    from fulltext.backends import __xml  # NOQA
+    from fulltext.backends import __zip  # NOQA
 
 
 # =====================================================================

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -17,6 +17,7 @@ from fulltext.util import is_file_path
 from fulltext.util import fobj_to_tempfile
 # Needed for external packages using pyinstaller
 import fulltext.backends  # NOQA
+import fulltext.backends.__text  # NOQA
 
 
 __all__ = ["get", "register_backend"]

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -118,7 +118,9 @@ if is_windows() and hasattr(sys, '_MEIPASS'):
     from fulltext.backends import __hwp  # NOQA
     from fulltext.backends import __json  # NOQA
     from fulltext.backends import __mbox  # NOQA
-    from fulltext.backends import __msg  # NOQA
+    # XXX couldn't find a way to install ExtractMessage lib with
+    # pyinstaller.
+    # from fulltext.backends import __msg  # NOQA
     from fulltext.backends import __ocr  # NOQA
     from fulltext.backends import __odt  # NOQA
     from fulltext.backends import __pdf  # NOQA

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -15,10 +15,7 @@ from fulltext.util import warn
 from fulltext.util import magic
 from fulltext.util import is_file_path
 from fulltext.util import fobj_to_tempfile
-# Needed for external packages using pyinstaller
-import fulltext.backends  # NOQA
-import fulltext.backends.__text  # NOQA
-
+from fulltext.util import is_windows
 
 __all__ = ["get", "register_backend"]
 
@@ -105,6 +102,50 @@ _TEXT_EXTS = set((
     ".yml",  # Yaml
     ".yxx",  # Bison source code file
 ))
+
+
+# Dirty hack for pyinstaller so that it includes these modules.
+if is_windows() and hasattr(sys, '_MEIPASS'):
+    from fulltext.backends import __msg  # NOQA
+    from fulltext.backends import __odt  # NOQA
+    from fulltext.backends import __pptx  # NOQA
+    from fulltext.backends import __epub  # NOQA
+    from fulltext.backends import __csv  # NOQA
+    from fulltext.backends import __ps  # NOQA
+    from fulltext.backends import __gz  # NOQA
+    from fulltext.backends import __eml  # NOQA
+    from fulltext.backends import __doc  # NOQA
+    from fulltext.backends import __html  # NOQA
+    from fulltext.backends import __rtf  # NOQA
+    from fulltext.backends import __mbox  # NOQA
+    from fulltext.backends import __docx  # NOQA
+    from fulltext.backends import __docx  # NOQA
+    from fulltext.backends import __doc  # NOQA
+    from fulltext.backends import __text  # NOQA
+    from fulltext.backends import __init__  # NOQA
+    from fulltext.backends import __eml  # NOQA
+    from fulltext.backends import __zip  # NOQA
+    from fulltext.backends import __html  # NOQA
+    from fulltext.backends import __gz  # NOQA
+    from fulltext.backends import __csv  # NOQA
+    from fulltext.backends import __hwp  # NOQA
+    from fulltext.backends import __msg  # NOQA
+    from fulltext.backends import __bin  # NOQA
+    from fulltext.backends import __ocr  # NOQA
+    from fulltext.backends import __xml  # NOQA
+    from fulltext.backends import __xlsx  # NOQA
+    from fulltext.backends import __mbox  # NOQA
+    from fulltext.backends import __json  # NOQA
+    from fulltext.backends import __pdf  # NOQA
+    from fulltext.backends import __init__  # NOQA
+    from fulltext.backends import __rar  # NOQA
+    from fulltext.backends import __json  # NOQA
+    from fulltext.backends import __epub  # NOQA
+    from fulltext.backends import __odt  # NOQA
+    from fulltext.backends import __bin  # NOQA
+    from fulltext.backends import __pdf  # NOQA
+    from fulltext.backends import __text  # NOQA
+    from fulltext.backends import __ocr  # NOQA
 
 
 # =====================================================================

--- a/fulltext/__init__.py
+++ b/fulltext/__init__.py
@@ -15,6 +15,8 @@ from fulltext.util import warn
 from fulltext.util import magic
 from fulltext.util import is_file_path
 from fulltext.util import fobj_to_tempfile
+# Needed for external packages using pyinstaller
+import fulltext.backends  # NOQA
 
 
 __all__ = ["get", "register_backend"]

--- a/fulltext/backends/__bin.py
+++ b/fulltext/backends/__bin.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     maketrans = bytes.maketrans
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 BUFFER_MAX = 1024 * 1024

--- a/fulltext/backends/__csv.py
+++ b/fulltext/backends/__csv.py
@@ -5,7 +5,7 @@ import csv
 from six import StringIO
 from six import PY3
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__doc.py
+++ b/fulltext/backends/__doc.py
@@ -4,7 +4,7 @@ import logging
 
 from fulltext.util import run, ShellError, MissingCommandException
 from fulltext.util import assert_cmd_exists
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import exiftool_title
 
 

--- a/fulltext/backends/__docx.py
+++ b/fulltext/backends/__docx.py
@@ -1,5 +1,5 @@
 import docx2txt
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import exiftool_title
 from fulltext.util import assert_cmd_exists
 

--- a/fulltext/backends/__eml.py
+++ b/fulltext/backends/__eml.py
@@ -3,7 +3,7 @@ from email import message_from_file
 import codecs
 
 from six import StringIO
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 # This is used by other modules, hence it's here.

--- a/fulltext/backends/__epub.py
+++ b/fulltext/backends/__epub.py
@@ -6,7 +6,7 @@ from ebooklib import epub
 from bs4 import BeautifulSoup
 from six import StringIO
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import assert_cmd_exists
 from fulltext.util import exiftool_title
 

--- a/fulltext/backends/__gz.py
+++ b/fulltext/backends/__gz.py
@@ -2,8 +2,7 @@ import gzip
 import logging
 from os.path import splitext, basename
 
-from fulltext import get, backend_from_fname, backend_from_fobj
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import is_file_path
 from fulltext.util import fobj_to_tempfile
 
@@ -36,6 +35,9 @@ class Backend(BaseBackend):
         return f, path
 
     def handle_fobj(self, path_or_file):
+        # Avoid circlar imports.
+        from fulltext import get, backend_from_fname, backend_from_fobj
+
         f, path = self.get_fobj_and_path(path_or_file)
         with f:
             orig_name = orig_fname(path)

--- a/fulltext/backends/__html.py
+++ b/fulltext/backends/__html.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from six import StringIO
 from six import PY3
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__hwp.py
+++ b/fulltext/backends/__hwp.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from fulltext.backends import __html
 from fulltext.util import run, assert_cmd_exists
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 def cmd(path, **kwargs):

--- a/fulltext/backends/__json.py
+++ b/fulltext/backends/__json.py
@@ -5,7 +5,7 @@ import re
 from six import StringIO
 from six import string_types
 from six import integer_types
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 STRIP_JSON = re.compile(r'[{}\'":\[\] ]+')

--- a/fulltext/backends/__mbox.py
+++ b/fulltext/backends/__mbox.py
@@ -4,7 +4,7 @@ import mailbox
 from six import StringIO
 
 from fulltext.backends.__eml import handle_fobj
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__msg.py
+++ b/fulltext/backends/__msg.py
@@ -2,7 +2,7 @@ import contextlib
 from six import StringIO
 
 from ExtractMsg import Message
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__ocr.py
+++ b/fulltext/backends/__ocr.py
@@ -9,7 +9,7 @@ from PIL import Image
 import pytesseract
 
 from fulltext.util import assert_cmd_exists, MissingCommandException
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 EXIF_ORIENTATION = 274  # cf ExifTags

--- a/fulltext/backends/__odt.py
+++ b/fulltext/backends/__odt.py
@@ -5,7 +5,7 @@ from lxml import etree
 
 from six import StringIO
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import assert_cmd_exists
 from fulltext.util import exiftool_title
 

--- a/fulltext/backends/__pdf.py
+++ b/fulltext/backends/__pdf.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 
 from fulltext.util import run, assert_cmd_exists
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import is_file_path, which
 from fulltext.compat import POSIX
 

--- a/fulltext/backends/__pptx.py
+++ b/fulltext/backends/__pptx.py
@@ -4,7 +4,7 @@ import os
 import pptx
 from six import StringIO
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import assert_cmd_exists
 from fulltext.util import exiftool_title
 

--- a/fulltext/backends/__ps.py
+++ b/fulltext/backends/__ps.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from fulltext.util import run, assert_cmd_exists, exiftool_title
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__rar.py
+++ b/fulltext/backends/__rar.py
@@ -6,7 +6,7 @@ import rarfile
 from six import StringIO
 from contextlib2 import ExitStack
 
-from fulltext import BaseBackend, get
+from fulltext.util import BaseBackend, get
 from fulltext.util import memoize
 
 

--- a/fulltext/backends/__rar.py
+++ b/fulltext/backends/__rar.py
@@ -6,7 +6,7 @@ import rarfile
 from six import StringIO
 from contextlib2 import ExitStack
 
-from fulltext.util import BaseBackend, get
+from fulltext.util import BaseBackend
 from fulltext.util import memoize
 
 
@@ -38,6 +38,7 @@ class Backend(BaseBackend):
                 rf.read()
 
     def handle_fobj(self, f):
+        from fulltext import get  # avoid circular import
         with ExitStack() as stack:
             text = StringIO()
             archive = stack.enter_context(rarfile.RarFile(f))

--- a/fulltext/backends/__rtf.py
+++ b/fulltext/backends/__rtf.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from fulltext.util import run, assert_cmd_exists, exiftool_title
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__text.py
+++ b/fulltext/backends/__text.py
@@ -11,7 +11,7 @@ Any decoding issues are ignored.
 from __future__ import absolute_import
 
 from six import StringIO
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 BUFFER_MAX = 1024 * 1024

--- a/fulltext/backends/__xlsx.py
+++ b/fulltext/backends/__xlsx.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import xlrd
 from six import StringIO
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 from fulltext.util import assert_cmd_exists, exiftool_title
 
 

--- a/fulltext/backends/__xml.py
+++ b/fulltext/backends/__xml.py
@@ -7,7 +7,7 @@ import bs4
 from six import StringIO
 from six import PY3
 
-from fulltext import BaseBackend
+from fulltext.util import BaseBackend
 
 
 class Backend(BaseBackend):

--- a/fulltext/backends/__zip.py
+++ b/fulltext/backends/__zip.py
@@ -6,7 +6,7 @@ import zipfile
 from six import StringIO
 from contextlib2 import ExitStack
 
-from fulltext import BaseBackend, get
+from fulltext.util import BaseBackend, get
 
 
 LOGGER = logging.getLogger(__name__)

--- a/fulltext/backends/__zip.py
+++ b/fulltext/backends/__zip.py
@@ -6,7 +6,7 @@ import zipfile
 from six import StringIO
 from contextlib2 import ExitStack
 
-from fulltext.util import BaseBackend, get
+from fulltext.util import BaseBackend
 
 
 LOGGER = logging.getLogger(__name__)
@@ -16,6 +16,7 @@ LOGGER.addHandler(logging.NullHandler())
 class Backend(BaseBackend):
 
     def handle_fobj(self, f):
+        from fulltext import get  # avoid circular import
         with ExitStack() as stack:
             text = StringIO()
             z = stack.enter_context(zipfile.ZipFile(f, 'r'))

--- a/fulltext/data/winmake.py
+++ b/fulltext/data/winmake.py
@@ -358,6 +358,9 @@ def pyinstaller():
     """Creates a stand alone Windows as dist/%s.exe.""" % PRJNAME
     def install_deps():
         sh("venv\\Scripts\\python -m pip install pyinstaller pypiwin32")
+        sh("venv\\Scripts\\python -m pip install "
+           "https://github.com/mattgwwalker/msg-extractor/zipball/"
+           "master#egg=ExtractMsg")
         sh("venv\\Scripts\\python setup.py install")
 
     def run_pyinstaller():

--- a/fulltext/util.py
+++ b/fulltext/util.py
@@ -338,3 +338,40 @@ else:
     # exiftool is also available on Windows
     def exiftool_title(*a, **kw):
         return None
+
+
+class BaseBackend(object):
+    """Base class for defining custom backend classes."""
+
+    def __init__(self, encoding, encoding_errors, kwargs):
+        """These are the same args passed to get() function."""
+        self.encoding = encoding
+        self.encoding_errors = encoding_errors
+        self.kwargs = kwargs
+
+    def setup(self):
+        """May be overridden by subclass. This is called before handle_
+        methods.
+        """
+        pass
+
+    def teardown(self):
+        """May be overridden by subclass. This is called after text
+        is extracted, also in case of exception.
+        """
+        pass
+
+    def check(self, title):
+        """May be overridden by subclass. This is called before text
+        extraction. If the overriding method raises an exception
+        a warning is printed and bin backend is used.
+        """
+        pass
+
+    def decode(self, s):
+        """Decode string."""
+        return s.decode(self.encoding, self.encoding_errors)
+
+    def handle_title(self, path_or_file):
+        """May be overridden by sublass in order to retrieve file title."""
+        return None


### PR DESCRIPTION
- fix circular imports occurring when using pyinstaller
- use a trick to make `fulltext/backend` modules visible to other projects using pyinstaller